### PR TITLE
Fix: add dependency checks to installation scripts

### DIFF
--- a/quickshell.sh
+++ b/quickshell.sh
@@ -53,6 +53,17 @@ error() {
 
 header
 
+# Verificação de dependências
+info "Verificando dependências..."
+
+if ! command -v quickshell &> /dev/null; then
+    error "Quickshell não está instalado. Instale com: pacman -S quickshell ou yay -S quickshell"
+    exit 1
+fi
+substep "Quickshell encontrado"
+
+success "Dependências verificadas"
+
 info "Initializing Installation..."
 substep "Target directory: $TARGET_DIR"
 

--- a/sddm.sh
+++ b/sddm.sh
@@ -54,6 +54,21 @@ error() {
 
 header
 
+# Verificação de dependências
+info "Verificando dependências..."
+
+if ! command -v sddm &> /dev/null; then
+    error "SDDM não está instalado. Instale com: pacman -S sddm"
+    exit 1
+fi
+substep "SDDM encontrado"
+
+if ! sudo -n true 2>/dev/null; then
+    substep "${C_YELLOW}Aviso: sudo pode solicitar sua senha durante a instalação${C_RESET}"
+fi
+
+success "Dependências verificadas"
+
 # Check if themes directory exists
 if [ ! -d "$THEMES_DIR" ]; then
     error "Themes directory not found at $THEMES_DIR"


### PR DESCRIPTION
## Summary

Adds pre-flight dependency validation to both installation scripts, preventing confusing errors when required packages are missing.

### Changes

- **sddm.sh**: checks if `sddm` is installed before proceeding; warns the user that `sudo` may prompt for a password during installation
- **quickshell.sh**: checks if `quickshell` is installed before proceeding

Both scripts now exit early with a clear, actionable error message if the required dependency is not found.

Closes #14

## Test plan

- [ ] Run `sddm.sh` without SDDM installed — should exit with a clear error message
- [ ] Run `sddm.sh` with SDDM installed — should proceed normally with a sudo warning
- [ ] Run `quickshell.sh` without Quickshell installed — should exit with a clear error message
- [ ] Run `quickshell.sh` with Quickshell installed — should proceed normally