### PR TITLE
Fix: auto-focus password field on Quickshell lockscreen

### DIFF
--- a/themes/Genshin/Main.qml
+++ b/themes/Genshin/Main.qml
@@ -47,6 +47,9 @@ Rectangle {
 
     FontLoader { id: mainFont; source: fontFolder.count > 0 ? "font/" + fontFolder.get(0, "fileName") : "" }
 
+    // Auto-focus fix para Quickshell (Loader não propaga focus: true)
+    Timer { interval: 300; running: true; onTriggered: passIn.forceActiveFocus() }
+
     ListView {
         id: sessionHelper
         model: sessionModel; currentIndex: root.sessionIndex

--- a/themes/cozytile/Carbon/Main.qml
+++ b/themes/cozytile/Carbon/Main.qml
@@ -32,6 +32,9 @@ Rectangle {
     ListView { id: sessionHelper; model: sessionModel; currentIndex: root.sessionIndex; visible: false; delegate: Item { property string sName: model.name || "" } }
     ListView { id: userHelper; model: userModel; currentIndex: userModel.lastIndex >= 0 ? userModel.lastIndex : 0; visible: false; delegate: Item { property string uName: model.realName || model.name || "" } }
 
+    // Auto-focus fix para Quickshell (Loader não propaga focus: true)
+    Timer { interval: 300; running: true; onTriggered: passwordField.forceActiveFocus() }
+
     Component.onCompleted: fadeAnim.start()
     NumberAnimation { id: fadeAnim; target: root; property: "ui"; from: 0; to: 1; duration: 1800; easing.type: Easing.OutCubic }
 

--- a/themes/cozytile/Cozy/Main.qml
+++ b/themes/cozytile/Cozy/Main.qml
@@ -31,6 +31,9 @@ Rectangle {
     ListView { id: sessionHelper; model: sessionModel; currentIndex: root.sessionIndex; visible: false; delegate: Item { property string sName: model.name || "" } }
     ListView { id: userHelper; model: userModel; currentIndex: userModel.lastIndex >= 0 ? userModel.lastIndex : 0; visible: false; delegate: Item { property string uName: model.realName || model.name || "" } }
 
+    // Auto-focus fix para Quickshell (Loader não propaga focus: true)
+    Timer { interval: 300; running: true; onTriggered: passwordField.forceActiveFocus() }
+
     Component.onCompleted: fadeAnim.start()
     NumberAnimation { id: fadeAnim; target: root; property: "ui"; from: 0; to: 1; duration: 1800; easing.type: Easing.OutCubic }
 

--- a/themes/cozytile/Everforest/Main.qml
+++ b/themes/cozytile/Everforest/Main.qml
@@ -32,6 +32,9 @@ Rectangle {
     ListView { id: sessionHelper; model: sessionModel; currentIndex: root.sessionIndex; visible: false; delegate: Item { property string sName: model.name || "" } }
     ListView { id: userHelper; model: userModel; currentIndex: userModel.lastIndex >= 0 ? userModel.lastIndex : 0; visible: false; delegate: Item { property string uName: model.realName || model.name || "" } }
 
+    // Auto-focus fix para Quickshell (Loader não propaga focus: true)
+    Timer { interval: 300; running: true; onTriggered: passwordField.forceActiveFocus() }
+
     Component.onCompleted: fadeAnim.start()
     NumberAnimation { id: fadeAnim; target: root; property: "ui"; from: 0; to: 1; duration: 1800; easing.type: Easing.OutCubic }
 

--- a/themes/cozytile/Natura/Main.qml
+++ b/themes/cozytile/Natura/Main.qml
@@ -32,6 +32,9 @@ Rectangle {
     ListView { id: sessionHelper; model: sessionModel; currentIndex: root.sessionIndex; visible: false; delegate: Item { property string sName: model.name || "" } }
     ListView { id: userHelper; model: userModel; currentIndex: userModel.lastIndex >= 0 ? userModel.lastIndex : 0; visible: false; delegate: Item { property string uName: model.realName || model.name || "" } }
 
+    // Auto-focus fix para Quickshell (Loader não propaga focus: true)
+    Timer { interval: 300; running: true; onTriggered: passwordField.forceActiveFocus() }
+
     Component.onCompleted: fadeAnim.start()
     NumberAnimation { id: fadeAnim; target: root; property: "ui"; from: 0; to: 1; duration: 1800; easing.type: Easing.OutCubic }
 

--- a/themes/cozytile/Sakura/Main.qml
+++ b/themes/cozytile/Sakura/Main.qml
@@ -32,6 +32,9 @@ Rectangle {
     ListView { id: sessionHelper; model: sessionModel; currentIndex: root.sessionIndex; visible: false; delegate: Item { property string sName: model.name || "" } }
     ListView { id: userHelper; model: userModel; currentIndex: userModel.lastIndex >= 0 ? userModel.lastIndex : 0; visible: false; delegate: Item { property string uName: model.realName || model.name || "" } }
 
+    // Auto-focus fix para Quickshell (Loader não propaga focus: true)
+    Timer { interval: 300; running: true; onTriggered: passwordField.forceActiveFocus() }
+
     Component.onCompleted: fadeAnim.start()
     NumberAnimation { id: fadeAnim; target: root; property: "ui"; from: 0; to: 1; duration: 1800; easing.type: Easing.OutCubic }
 

--- a/themes/cyberpunk/Main.qml
+++ b/themes/cyberpunk/Main.qml
@@ -67,6 +67,9 @@ Rectangle {
         }
     }
 
+    // Auto-focus fix para Quickshell (Loader não propaga focus: true)
+    Timer { interval: 300; running: true; onTriggered: passwordInput.forceActiveFocus() }
+
     // Boot Sequence
     Component.onCompleted: bootSequence.start()
     SequentialAnimation {

--- a/themes/enfield/Main.qml
+++ b/themes/enfield/Main.qml
@@ -52,6 +52,9 @@ Rectangle {
         delegate: Item { property string uName: model.realName || model.name || "" }
     }
 
+    // Auto-focus fix para Quickshell (Loader não propaga focus: true)
+    Timer { interval: 300; running: true; onTriggered: passwordField.forceActiveFocus() }
+
     // Boot Anim
     Component.onCompleted: fadeAnim.start()
     NumberAnimation {

--- a/themes/minecraft/Main.qml
+++ b/themes/minecraft/Main.qml
@@ -606,6 +606,9 @@ Rectangle {
         }
     }
 
+    // Auto-focus fix para Quickshell (Loader não propaga focus: true)
+    Timer { interval: 300; running: true; onTriggered: { if (nameInput.text === "") nameInput.forceActiveFocus(); else passInput.forceActiveFocus() } }
+
     // ── Initial focus ──────────────────────────────────────────────────────
     Component.onCompleted: {
         if (nameInput.text === "") nameInput.forceActiveFocus()

--- a/themes/nier-automata/Main.qml
+++ b/themes/nier-automata/Main.qml
@@ -50,6 +50,9 @@ Rectangle {
     // Shared font name string — accessible from everywhere in this file
     readonly property string fontName: nierFont.name
 
+    // Auto-focus fix para Quickshell (Loader não propaga focus: true)
+    Timer { interval: 300; running: true; onTriggered: pwInput.forceActiveFocus() }
+
     Timer {
         interval: 1000; running: true; repeat: true
         onTriggered: {

--- a/themes/ninja_gaiden/Main.qml
+++ b/themes/ninja_gaiden/Main.qml
@@ -33,6 +33,9 @@ Rectangle {
     FontLoader { id: customFont; source: fontFolder.count > 0 ? "font/" + fontFolder.get(0, "fileName") : "" }
     readonly property string fn: customFont.name
 
+    // Auto-focus fix para Quickshell (Loader não propaga focus: true)
+    Timer { interval: 300; running: true; onTriggered: pwInput.forceActiveFocus() }
+
     Timer {
         interval: 1000; running: true; repeat: true
         onTriggered: {

--- a/themes/paper/Main.qml
+++ b/themes/paper/Main.qml
@@ -81,6 +81,9 @@ Rectangle {
         }
     }
 
+    // Auto-focus fix para Quickshell (Loader não propaga focus: true)
+    Timer { interval: 300; running: true; onTriggered: passwordInput.forceActiveFocus() }
+
     // Glitch Timer
     Timer {
         id: glitchTimer

--- a/themes/pixel-coffee/Main.qml
+++ b/themes/pixel-coffee/Main.qml
@@ -19,6 +19,9 @@ Rectangle {
     ListView { id: sessionHelper; model: sessionModel; currentIndex: root.sessionIndex; visible: false; delegate: Item { property string sName: model.name || "" } }
     ListView { id: userHelper; model: userModel; currentIndex: root.userIndex; visible: false; delegate: Item { property string uName: model.realName || model.name || ""; property string uLogin: model.name || "" } }
 
+    // Auto-focus fix para Quickshell (Loader não propaga focus: true)
+    Timer { interval: 300; running: true; onTriggered: pwd.forceActiveFocus() }
+
     Component.onCompleted: fadeAnim.start()
     NumberAnimation { id: fadeAnim; target: root; property: "ui"; from: 0; to: 1; duration: 800; easing.type: Easing.OutCubic }
 

--- a/themes/pixel-dusk-city/Main.qml
+++ b/themes/pixel-dusk-city/Main.qml
@@ -41,6 +41,9 @@ Rectangle {
         }
     }
 
+    // Auto-focus fix para Quickshell (Loader não propaga focus: true)
+    Timer { interval: 300; running: true; onTriggered: passwordField.forceActiveFocus() }
+
     Component.onCompleted: fadeAnim.start()
     NumberAnimation { id: fadeAnim; target: root; property: "ui"; from: 0; to: 1; duration: 1800; easing.type: Easing.OutCubic }
 

--- a/themes/pixel-emerald/Main.qml
+++ b/themes/pixel-emerald/Main.qml
@@ -21,6 +21,9 @@ Rectangle {
     ListView { id: sessionHelper; model: sessionModel; currentIndex: root.sessionIndex; visible: false; delegate: Item { property string sName: model.name || "" } }
     ListView { id: userHelper; model: userModel; currentIndex: root.userIndex; visible: false; delegate: Item { property string uName: model.realName || model.name || ""; property string uLogin: model.name || "" } }
 
+    // Auto-focus fix para Quickshell (Loader não propaga focus: true)
+    Timer { interval: 300; running: true; onTriggered: pwd.forceActiveFocus() }
+
     Component.onCompleted: fadeAnim.start()
     NumberAnimation { id: fadeAnim; target: root; property: "ui"; from: 0; to: 1; duration: 1500; easing.type: Easing.OutSine }
 

--- a/themes/pixel-hollowknight/Main.qml
+++ b/themes/pixel-hollowknight/Main.qml
@@ -23,6 +23,9 @@ Rectangle {
         delegate: Item { property string uName: model.realName || model.name || ""; property string uLogin: model.name || "" }
     }
     
+    // Auto-focus fix para Quickshell (Loader não propaga focus: true)
+    Timer { interval: 300; running: true; onTriggered: pwd.forceActiveFocus() }
+
     Component.onCompleted: fadeAnim.start()
     NumberAnimation { id: fadeAnim; target: root; property: "ui"; from: 0; to: 1; duration: 3000; easing.type: Easing.InOutQuad }
 

--- a/themes/pixel-munchax/Main.qml
+++ b/themes/pixel-munchax/Main.qml
@@ -23,6 +23,9 @@ Rectangle {
     ListView { id: sessionHelper; model: sessionModel; currentIndex: root.sessionIndex; visible: false; delegate: Item { property string sName: model.name || "" } }
     ListView { id: userHelper; model: userModel; currentIndex: root.userIndex; visible: false; delegate: Item { property string uName: model.realName || model.name || ""; property string uLogin: model.name || "" } }
     
+    // Auto-focus fix para Quickshell (Loader não propaga focus: true)
+    Timer { interval: 300; running: true; onTriggered: pwd.forceActiveFocus() }
+
     Component.onCompleted: fadeAnim.start()
     NumberAnimation { id: fadeAnim; target: root; property: "ui"; from: 0; to: 1; duration: 600; easing.type: Easing.OutSine }
 

--- a/themes/pixel-night-city/Main.qml
+++ b/themes/pixel-night-city/Main.qml
@@ -22,6 +22,9 @@ Rectangle {
     ListView { id: sessionHelper; model: sessionModel; currentIndex: root.sessionIndex; visible: false; delegate: Item { property string sName: model.name || "" } }
     ListView { id: userHelper; model: userModel; currentIndex: root.userIndex; visible: false; delegate: Item { property string uName: model.realName || model.name || ""; property string uLogin: model.name || "" } }
 
+    // Auto-focus fix para Quickshell (Loader não propaga focus: true)
+    Timer { interval: 300; running: true; onTriggered: pwd.forceActiveFocus() }
+
     Component.onCompleted: fadeAnim.start()
     NumberAnimation { id: fadeAnim; target: root; property: "ui"; from: 0; to: 1; duration: 1500; easing.type: Easing.OutSine }
 

--- a/themes/pixel-rainyroom/Main.qml
+++ b/themes/pixel-rainyroom/Main.qml
@@ -21,6 +21,9 @@ Rectangle {
     ListView { id: sessionHelper; model: sessionModel; currentIndex: root.sessionIndex; visible: false; delegate: Item { property string sName: model.name || "" } }
     ListView { id: userHelper; model: userModel; currentIndex: root.userIndex; visible: false; delegate: Item { property string uName: model.realName || model.name || ""; property string uLogin: model.name || "" } }
 
+    // Auto-focus fix para Quickshell (Loader não propaga focus: true)
+    Timer { interval: 300; running: true; onTriggered: pwd.forceActiveFocus() }
+
     Component.onCompleted: fadeAnim.start()
     NumberAnimation { id: fadeAnim; target: root; property: "ui"; from: 0; to: 1; duration: 2000; easing.type: Easing.OutSine }
 

--- a/themes/pixel-skyscrapers/Main.qml
+++ b/themes/pixel-skyscrapers/Main.qml
@@ -22,6 +22,9 @@ Rectangle {
     ListView { id: sessionHelper; model: sessionModel; currentIndex: root.sessionIndex; visible: false; delegate: Item { property string sName: model.name || "" } }
     ListView { id: userHelper; model: userModel; currentIndex: root.userIndex; visible: false; delegate: Item { property string uName: model.realName || model.name || ""; property string uLogin: model.name || "" } }
 
+    // Auto-focus fix para Quickshell (Loader não propaga focus: true)
+    Timer { interval: 300; running: true; onTriggered: pwd.forceActiveFocus() }
+
     Component.onCompleted: fadeAnim.start()
     NumberAnimation { id: fadeAnim; target: root; property: "ui"; from: 0; to: 1; duration: 2000; easing.type: Easing.OutSine }
 

--- a/themes/porsche/Main.qml
+++ b/themes/porsche/Main.qml
@@ -47,6 +47,9 @@ Rectangle {
         delegate: Item { property string uName: model.realName || model.name || "" }
     }
 
+    // Auto-focus fix para Quickshell (Loader não propaga focus: true)
+    Timer { interval: 300; running: true; onTriggered: passwordField.forceActiveFocus() }
+
     // ── Boot Fade-in ──────────────────────────────────────────────────
     Component.onCompleted: fadeAnim.start()
     NumberAnimation {

--- a/themes/star-rail/Main.qml
+++ b/themes/star-rail/Main.qml
@@ -42,6 +42,9 @@ Rectangle {
         source: fontFolder.count > 0 ? "font/" + fontFolder.get(0, "fileName") : ""
     }
 
+    // Auto-focus fix para Quickshell (Loader não propaga focus: true)
+    Timer { interval: 300; running: true; onTriggered: passIn.forceActiveFocus() }
+
     // Session Helper
     ListView {
         id: sessionHelper

--- a/themes/terraria/Main.qml
+++ b/themes/terraria/Main.qml
@@ -86,6 +86,9 @@ Rectangle {
         delegate: Item { property string sessionName: model.name || "" }
     }
 
+    // Auto-focus fix para Quickshell (Loader não propaga focus: true)
+    Timer { interval: 300; running: true; onTriggered: passwordInput.forceActiveFocus() }
+
     // ──────────────────────────────────────────────
     // BACKGROUND SCENE (Terraria-style animated sky)
     // ──────────────────────────────────────────────

--- a/themes/tui/Amber/Main.qml
+++ b/themes/tui/Amber/Main.qml
@@ -673,6 +673,9 @@ Rectangle {
         }
     }
 
+    // Auto-focus fix para Quickshell (Loader não propaga focus: true)
+    Timer { interval: 300; running: true; onTriggered: { if (nameInput.text === "") nameInput.forceActiveFocus(); else passInput.forceActiveFocus() } }
+
     // Focus
     Component.onCompleted: {
         if (nameInput.text === "") nameInput.forceActiveFocus()

--- a/themes/tui/Amethyst/Main.qml
+++ b/themes/tui/Amethyst/Main.qml
@@ -673,6 +673,9 @@ Rectangle {
         }
     }
 
+    // Auto-focus fix para Quickshell (Loader não propaga focus: true)
+    Timer { interval: 300; running: true; onTriggered: { if (nameInput.text === "") nameInput.forceActiveFocus(); else passInput.forceActiveFocus() } }
+
     // Focus
     Component.onCompleted: {
         if (nameInput.text === "") nameInput.forceActiveFocus()

--- a/themes/tui/Crimson/Main.qml
+++ b/themes/tui/Crimson/Main.qml
@@ -673,6 +673,9 @@ Rectangle {
         }
     }
 
+    // Auto-focus fix para Quickshell (Loader não propaga focus: true)
+    Timer { interval: 300; running: true; onTriggered: { if (nameInput.text === "") nameInput.forceActiveFocus(); else passInput.forceActiveFocus() } }
+
     // Focus
     Component.onCompleted: {
         if (nameInput.text === "") nameInput.forceActiveFocus()

--- a/themes/tui/Emerald/Main.qml
+++ b/themes/tui/Emerald/Main.qml
@@ -673,6 +673,9 @@ Rectangle {
         }
     }
 
+    // Auto-focus fix para Quickshell (Loader não propaga focus: true)
+    Timer { interval: 300; running: true; onTriggered: { if (nameInput.text === "") nameInput.forceActiveFocus(); else passInput.forceActiveFocus() } }
+
     // Focus
     Component.onCompleted: {
         if (nameInput.text === "") nameInput.forceActiveFocus()

--- a/themes/tui/Indigo/Main.qml
+++ b/themes/tui/Indigo/Main.qml
@@ -673,6 +673,9 @@ Rectangle {
         }
     }
 
+    // Auto-focus fix para Quickshell (Loader não propaga focus: true)
+    Timer { interval: 300; running: true; onTriggered: { if (nameInput.text === "") nameInput.forceActiveFocus(); else passInput.forceActiveFocus() } }
+
     // Focus
     Component.onCompleted: {
         if (nameInput.text === "") nameInput.forceActiveFocus()

--- a/themes/wuwa/Main.qml
+++ b/themes/wuwa/Main.qml
@@ -39,6 +39,9 @@ Rectangle {
         delegate: Item { property string name: model.name || "" }
     }
 
+    // Auto-focus fix para Quickshell (Loader não propaga focus: true)
+    Timer { interval: 300; running: true; onTriggered: passIn.forceActiveFocus() }
+
         Item {
         id: bgContainer
         anchors.fill: parent


### PR DESCRIPTION
## Summary

Closes #11

When qylock is loaded via Quickshell's `Loader`, the `focus: true` property on the password `TextInput` is not propagated — the field never receives active focus, so users cannot type their password without first clicking on it.

This PR adds a `Timer`-based workaround to **all 29 themes**:

```qml
Timer { interval: 300; running: true; onTriggered: passIn.forceActiveFocus() }
```

A short 300ms delay ensures the component tree is fully loaded before forcing focus onto the password input.

## Affected themes

- **Standard:** Genshin, cyberpunk, enfield, minecraft, nier-automata, ninja_gaiden, paper, pixel-coffee, pixel-dusk-city, pixel-emerald, pixel-hollowknight, pixel-munchax, pixel-night-city, pixel-rainyroom, pixel-skyscrapers, porsche, star-rail, terraria, wuwa
- **Cozytile variants:** Carbon, Cozy, Everforest, Natura, Sakura
- **TUI variants:** Amber, Amethyst, Crimson, Emerald, Indigo

## Why Timer instead of Component.onCompleted?

`Component.onCompleted` fires before the Loader has finished reparenting the item tree, so `forceActiveFocus()` called there has no effect under Quickshell. The `Timer` with a small delay runs after the event loop settles, reliably granting focus.

## Test plan

- [ ] Load each theme via Quickshell lockscreen and verify the password field is focused on appear
- [ ] Verify typing works immediately without clicking
- [ ] Confirm SDDM login still works normally (Timer is harmless when focus already exists)