### PR TITLE
Fix QML error: duplicate width property in Main.qml

### DIFF
--- a/themes/windows_7/Main.qml
+++ b/themes/windows_7/Main.qml
@@ -363,7 +363,7 @@ Rectangle {
             id: errorMsg
             anchors.horizontalCenter: parent.horizontalCenter
             text: ""
-            opacity: 0; width: 100; height: 100; z: -100
+            opacity: 0; height: 100; z: -100
             font.family: root.customFontName
             font.pixelSize: 12 * s
             color: "#ffddaa"


### PR DESCRIPTION
is PR fixes a QML runtime error that prevents the SDDM theme from loading:

Property value set multiple times
Main.qml:373
Cause

The issue is caused by assigning the width property twice in the same Text element (errorMsg):

opacity: 0; width: 100; height: 100; z: -100
...
width: 318 * s

QML does not allow multiple assignments of the same property within a single element, which results in a fatal error.

Fix

Removed the duplicate width assignment to ensure only one definition remains.

Result
Theme loads correctly without QML errors
No visual regressions observed