### PR TITLE
Fixed pokemon name

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Point your Window Manager keybind (e.g., in Hyprland, Qtile, Sway, or i3) direct
     </tr>
     <tr>
       <td align="center" width="50%" style="padding: 15px; border: none;">
-        <b>Pixel · Munchax</b><br><br>
+        <b>Pixel · Munchlax</b><br><br>
         <img src="./Assets/pixel_munchax.gif" width="100%" style="border-radius: 12px; box-shadow: 0 4px 15px rgba(0,0,0,0.3);"/>
       </td>
       <td align="center" width="50%" style="padding: 15px; border: none;">


### PR DESCRIPTION
Munchlax's name had a typo and it was just bugging the hell out of me