### PR TITLE
Reduce git repo size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 .git/
 themes/**/*.mp4
 migrate-videos.sh
-PR_DESCRIPTION.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .git/
+themes/**/*.mp4
+migrate-videos.sh
+PR_DESCRIPTION.md

--- a/quickshell.sh
+++ b/quickshell.sh
@@ -48,6 +48,103 @@ error() {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
+#  Video Download Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+detect_repo_url() {
+    local dir="$1"
+    local url
+
+    if command -v git &>/dev/null && [ -d "$dir/.git" ]; then
+        url=$(git -C "$dir" remote get-url origin 2>/dev/null || true)
+    fi
+
+    if [ -z "$url" ]; then
+        echo "https://github.com/SL-Pirate/qylock"
+        return
+    fi
+
+    # SSH -> HTTPS
+    if [[ "$url" == git@github.com:* ]]; then
+        url="${url#git@github.com:}"
+        url="${url%.git}"
+        echo "https://github.com/$url"
+    elif [[ "$url" == https://github.com/* ]]; then
+        url="${url%.git}"
+        echo "$url"
+    else
+        echo "https://github.com/SL-Pirate/qylock"
+    fi
+}
+
+ensure_videos() {
+    local theme="$1"
+    local tdir="$2"
+    local sdir="$3"
+    local manifest="$sdir/videos.conf"
+
+    # No manifest = pre-migration clone, videos are still in-tree
+    [ ! -f "$manifest" ] && return 0
+
+    local entry
+    entry=$(grep "^${theme}:" "$manifest" 2>/dev/null || true)
+    [ -z "$entry" ] && return 0
+
+    local files="${entry#*:}"
+    IFS=',' read -ra vids <<< "$files"
+
+    # Figure out which ones are missing
+    local need=()
+    for v in "${vids[@]}"; do
+        [ ! -f "$tdir/$theme/$v" ] && need+=("$v")
+    done
+    [ ${#need[@]} -eq 0 ] && return 0
+
+    # Pick a download tool
+    local dlcmd=""
+    if command -v curl &>/dev/null; then
+        dlcmd="curl"
+    elif command -v wget &>/dev/null; then
+        dlcmd="wget"
+    else
+        error "curl or wget is required to download theme videos."
+        return 1
+    fi
+
+    local base
+    base=$(detect_repo_url "$sdir")
+    local tag="theme-videos"
+    local ok=1
+
+    info "Downloading video backgrounds for '${theme}'..."
+
+    for v in "${need[@]}"; do
+        local asset="${theme}--${v}"
+        local dest="$tdir/$theme/$v"
+        substep "Fetching ${v}..."
+
+        if [ "$dlcmd" = "curl" ]; then
+            if ! curl -fSL --progress-bar -o "$dest" "$base/releases/download/$tag/$asset"; then
+                rm -f "$dest"; ok=0
+                error "Failed to download ${v}"
+            fi
+        else
+            if ! wget -q --show-progress -O "$dest" "$base/releases/download/$tag/$asset"; then
+                rm -f "$dest"; ok=0
+                error "Failed to download ${v}"
+            fi
+        fi
+    done
+
+    if [ "$ok" -eq 0 ]; then
+        error "Some videos could not be downloaded."
+        return 1
+    fi
+
+    success "Video backgrounds ready"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
 #  Core Logic
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -173,6 +270,16 @@ if [ "$THEME_NAME" == "Genshin" ]; then
         1) sed -i "s/^background_mode=.*/background_mode=time/" "$THEMES_DIR/Genshin/theme.conf" ;;
         2) sed -i "s/^background_mode=.*/background_mode=random/" "$THEMES_DIR/Genshin/theme.conf" ;;
     esac
+fi
+
+# Fetch video backgrounds from GitHub releases if they aren't bundled locally
+if ! ensure_videos "$THEME_NAME" "$THEMES_DIR" "$DIR"; then
+    echo -ne "${C_MAIN}${C_BOLD} ╰─ ${C_YELLOW}Continue without video backgrounds? (y/n): ${C_RESET}"
+    read -rp "" SKIP_VID
+    if [[ ! "$SKIP_VID" =~ ^[Yy]$ ]]; then
+        error "Installation aborted."
+        exit 1
+    fi
 fi
 
 # Check for fonts in the selected theme

--- a/sddm.sh
+++ b/sddm.sh
@@ -56,6 +56,103 @@ error() {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
+#  Video Download Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+detect_repo_url() {
+    local dir="$1"
+    local url
+
+    if command -v git &>/dev/null && [ -d "$dir/.git" ]; then
+        url=$(git -C "$dir" remote get-url origin 2>/dev/null || true)
+    fi
+
+    if [ -z "$url" ]; then
+        echo "https://github.com/SL-Pirate/qylock"
+        return
+    fi
+
+    # SSH -> HTTPS
+    if [[ "$url" == git@github.com:* ]]; then
+        url="${url#git@github.com:}"
+        url="${url%.git}"
+        echo "https://github.com/$url"
+    elif [[ "$url" == https://github.com/* ]]; then
+        url="${url%.git}"
+        echo "$url"
+    else
+        echo "https://github.com/SL-Pirate/qylock"
+    fi
+}
+
+ensure_videos() {
+    local theme="$1"
+    local tdir="$2"
+    local sdir="$3"
+    local manifest="$sdir/videos.conf"
+
+    # No manifest = pre-migration clone, videos are still in-tree
+    [ ! -f "$manifest" ] && return 0
+
+    local entry
+    entry=$(grep "^${theme}:" "$manifest" 2>/dev/null || true)
+    [ -z "$entry" ] && return 0
+
+    local files="${entry#*:}"
+    IFS=',' read -ra vids <<< "$files"
+
+    # Figure out which ones are missing
+    local need=()
+    for v in "${vids[@]}"; do
+        [ ! -f "$tdir/$theme/$v" ] && need+=("$v")
+    done
+    [ ${#need[@]} -eq 0 ] && return 0
+
+    # Pick a download tool
+    local dlcmd=""
+    if command -v curl &>/dev/null; then
+        dlcmd="curl"
+    elif command -v wget &>/dev/null; then
+        dlcmd="wget"
+    else
+        error "curl or wget is required to download theme videos."
+        return 1
+    fi
+
+    local base
+    base=$(detect_repo_url "$sdir")
+    local tag="theme-videos"
+    local ok=1
+
+    info "Downloading video backgrounds for '${theme}'..."
+
+    for v in "${need[@]}"; do
+        local asset="${theme}--${v}"
+        local dest="$tdir/$theme/$v"
+        substep "Fetching ${v}..."
+
+        if [ "$dlcmd" = "curl" ]; then
+            if ! curl -fSL --progress-bar -o "$dest" "$base/releases/download/$tag/$asset"; then
+                rm -f "$dest"; ok=0
+                error "Failed to download ${v}"
+            fi
+        else
+            if ! wget -q --show-progress -O "$dest" "$base/releases/download/$tag/$asset"; then
+                rm -f "$dest"; ok=0
+                error "Failed to download ${v}"
+            fi
+        fi
+    done
+
+    if [ "$ok" -eq 0 ]; then
+        error "Some videos could not be downloaded."
+        return 1
+    fi
+
+    success "Video backgrounds ready"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
 #  Core Logic
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -217,6 +314,16 @@ if [ "$FONT_COUNT" -eq 0 ]; then
     echo -e "${C_YELLOW}${C_BOLD} │${C_RESET}  ${C_DIM}Please put the .ttf/.otf file in:${C_RESET}"
     echo -e "${C_YELLOW}${C_BOLD} │${C_RESET}  ${C_ACCENT}$THEMES_DIR/$SELECTED_THEME/font/${C_RESET}"
     echo -e "${C_YELLOW}${C_BOLD} ╰─ ${C_DIM}Refer to README.md for font suggestions.${C_RESET}\n"
+fi
+
+# Fetch video backgrounds from GitHub releases if they aren't bundled locally
+if ! ensure_videos "$SELECTED_THEME" "$THEMES_DIR" "$SCRIPT_DIR"; then
+    echo -ne "${C_MAIN}${C_BOLD} ╰─ ${C_YELLOW}Continue without video backgrounds? (y/n): ${C_RESET}"
+    read -rp "" SKIP_VID
+    if [[ ! "$SKIP_VID" =~ ^[Yy]$ ]]; then
+        error "Installation aborted."
+        exit 1
+    fi
 fi
 
 # Installation Logic

--- a/videos.conf
+++ b/videos.conf
@@ -1,0 +1,24 @@
+# Theme video manifest — maps themes to their video background files.
+# These are hosted as GitHub release assets and downloaded on demand
+# by the installer scripts when a theme is selected.
+#
+# Format: theme_name:file1,file2,...
+Genshin:dawn.mp4,day.mp4,dusk.mp4,night.mp4
+R1999_1:bg.mp4
+R1999_2:bg.mp4
+dog-samurai:bg.mp4
+enfield:bg.mp4
+forest:bg.mp4
+last-of-us:bg.mp4
+pixel-coffee:bg.mp4
+pixel-dusk-city:bg.mp4
+pixel-emerald:bg.mp4
+pixel-hollowknight:bg.mp4
+pixel-munchlax:bg.mp4
+pixel-night-city:bg.mp4
+pixel-rainyroom:bg.mp4
+pixel-skyscrapers:bg.mp4
+star-rail:bg.mp4
+sword:bg.mp4
+winter:bg.mp4
+wuwa:bg.mp4


### PR DESCRIPTION
# Move theme videos to GitHub releases, compress gallery GIFs

## Summary

The repo currently weighs ~973MB (git pack) due to theme video backgrounds and gallery GIF previews. The working tree alone has ~434MB of `.mp4` files and ~116MB of `.gif` files. This makes cloning unnecessarily painful, especially since any given user only needs the video(s) for the single theme they pick, and nobody needs full-resolution 1366x768 GIFs just to browse the README.

This PR:

- Moves all 22 `.mp4` files (across 19 themes) out of the git tree and into a GitHub release (`theme-videos`)
- Modifies `sddm.sh` and `quickshell.sh` to automatically download only the required video(s) when a theme is selected during installation
- Adds a `videos.conf` manifest that maps each theme to its video files
- Updates `.gitignore` to prevent videos from being re-committed

The video download is transparent to the user -- it happens right after theme selection, shows a progress bar, and gracefully handles failures (offering to continue without videos if the download fails). Themes that don't use videos (minecraft, nier-automata, terraria, etc.) are unaffected.

### About the gallery GIFs

The 22 preview GIFs in `Assets/` are rendered at full 1366x768 resolution but only displayed at ~400-500px wide in the README gallery. They're solely referenced by `README.md` and are never used by any theme, script, or installer.

The migration script includes a step that compresses these GIFs using `gifsicle` (lossy + resize to 480px wide). Expected reduction: ~116MB down to roughly 10-15MB. This can be skipped with `--skip-gif-compress` if needed. The compressed GIFs stay in the repo -- they're small enough that it's not worth the complexity of hosting them externally.

The `filter-repo` history purge step accounts for both the `.mp4` files and the original oversized `.gif` blobs, so the repo actually shrinks.

### Backward compatibility

- If `videos.conf` is missing (e.g. older clone where videos are still in-tree), the download logic is skipped entirely
- If video files are already present on disk, nothing is downloaded
- The repo URL for downloads is auto-detected from `git remote`, so forks work out of the box

## Changed files

| File | What changed |
|---|---|
| `videos.conf` | New manifest mapping themes to their video files |
| `.gitignore` | Added `themes/**/*.mp4` pattern |
| `sddm.sh` | Added `detect_repo_url()` + `ensure_videos()` functions; call site before theme installation |
| `quickshell.sh` | Same two functions; call site before font check |

## Test plan

- [x] Select a video theme (e.g. `forest`) -- verify the video downloads and the theme installs correctly
- [ ] Select a non-video theme (e.g. `minecraft`) -- verify no download is attempted
- [ ] Run with videos already present on disk -- verify no redundant downloads
- [ ] Disconnect from internet, select a video theme -- verify graceful error message and option to continue
- [ ] Remove `videos.conf` and run -- verify scripts behave exactly like before (no download logic triggered)
- [x] Check that compressed GIFs still render correctly in the README gallery

---

## Migration guide (for maintainers)

After merging this PR, you'll want to upload the videos to a GitHub release, compress the gallery GIFs, and purge the bloated history. Here's the full process.

### Prerequisites

- [GitHub CLI (`gh`)](https://cli.github.com) installed and authenticated
- [`gifsicle`](https://www.lcdf.org/gifsicle/) installed for GIF compression (e.g. `pacman -S gifsicle` / `apt install gifsicle`)
- All `.mp4` files still present in the working tree (i.e. run this before deleting them)

### Step 1: Save the migration script

Create `migrate-videos.sh` in the repo root and make it executable. This script is already in `.gitignore` so it won't be committed.

```bash
#!/usr/bin/env bash
#
# migrate-videos.sh — One-time migration script for maintainers.
#
# Uploads all theme .mp4 files to a GitHub release, generates the
# videos.conf manifest, and removes the videos from the working tree.
# After running this, you'll want to rewrite history with git-filter-repo
# to actually shrink the repo.
#
# Prerequisites:
#   - gh CLI installed and authenticated (https://cli.github.com)
#   - All .mp4 files still present in themes/

set -euo pipefail

SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
THEMES_DIR="$SCRIPT_DIR/themes"
ASSETS_DIR="$SCRIPT_DIR/Assets"
RELEASE_TAG="theme-videos"
MANIFEST="$SCRIPT_DIR/videos.conf"

SKIP_GIF=0
for arg in "$@"; do
    case "$arg" in
        --skip-gif-compress) SKIP_GIF=1 ;;
        -h|--help)
            echo "Usage: $0 [--skip-gif-compress]"
            echo ""
            echo "  --skip-gif-compress  Skip the GIF gallery compression step"
            exit 0
            ;;
        *) echo "Unknown option: $arg"; exit 1 ;;
    esac
done

# ── Preflight ────────────────────────────────────────────────────────────────

for cmd in gh git; do
    if ! command -v "$cmd" &>/dev/null; then
        echo "Error: '$cmd' is required but not found in PATH." >&2
        exit 1
    fi
done

REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)
if [ -z "$REPO" ]; then
    echo "Error: could not determine the GitHub repository." >&2
    echo "Make sure 'gh' is authenticated and you're inside the repo." >&2
    exit 1
fi

echo "Repository : $REPO"
echo "Release tag: $RELEASE_TAG"
echo ""

# ── Step 1: Catalog videos ──────────────────────────────────────────────────

declare -A THEME_VIDEOS
total=0

while IFS= read -r mp4; do
    rel="${mp4#$THEMES_DIR/}"          # e.g. forest/bg.mp4
    theme="${rel%%/*}"
    file="${rel#*/}"

    if [ -n "${THEME_VIDEOS[$theme]+x}" ]; then
        THEME_VIDEOS[$theme]="${THEME_VIDEOS[$theme]},$file"
    else
        THEME_VIDEOS[$theme]="$file"
    fi
    total=$((total + 1))
done < <(find "$THEMES_DIR" -name "*.mp4" -type f | sort)

if [ "$total" -eq 0 ]; then
    echo "No .mp4 files found under $THEMES_DIR — nothing to migrate."
    exit 0
fi

echo "Found $total video(s) across ${#THEME_VIDEOS[@]} theme(s)."
echo ""

# ── Step 2: Create the release ───────────────────────────────────────────────

if gh release view "$RELEASE_TAG" &>/dev/null; then
    echo "Release '$RELEASE_TAG' already exists — assets will be updated."
else
    echo "Creating release '$RELEASE_TAG'..."
    gh release create "$RELEASE_TAG" \
        --title "Theme Video Assets" \
        --notes "Video backgrounds for themes. Downloaded automatically during installation."
fi
echo ""

# ── Step 3: Upload assets ───────────────────────────────────────────────────

TMPDIR=$(mktemp -d)
trap 'rm -rf "$TMPDIR"' EXIT

failed=0
for theme in $(echo "${!THEME_VIDEOS[@]}" | tr ' ' '\n' | sort); do
    IFS=',' read -ra files <<< "${THEME_VIDEOS[$theme]}"
    for file in "${files[@]}"; do
        asset="${theme}--${file}"
        src="$THEMES_DIR/$theme/$file"
        tmp="$TMPDIR/$asset"

        echo -n "  Uploading $asset ... "
        cp "$src" "$tmp"
        if gh release upload "$RELEASE_TAG" "$tmp" --clobber 2>/dev/null; then
            echo "ok"
        else
            echo "FAILED"
            failed=1
        fi
        rm -f "$tmp"
    done
done

echo ""
if [ "$failed" -eq 1 ]; then
    echo "WARNING: Some uploads failed. Check the release page and re-run if needed."
fi

# ── Step 4: Compress README gallery GIFs ─────────────────────────────────────

if [ "$SKIP_GIF" -eq 1 ]; then
    echo "Skipping GIF compression (--skip-gif-compress)."
    echo ""
elif [ ! -d "$ASSETS_DIR" ]; then
    echo "No Assets/ directory found, skipping GIF compression."
    echo ""
else
    if ! command -v gifsicle &>/dev/null; then
        echo "WARNING: 'gifsicle' is not installed. Skipping GIF compression."
        echo "  Install it (e.g. pacman -S gifsicle / apt install gifsicle)"
        echo "  and re-run, or pass --skip-gif-compress to skip intentionally."
        echo ""
    else
        echo "Compressing gallery GIFs in Assets/ ..."
        gif_count=0
        before_total=0
        after_total=0

        for gif in "$ASSETS_DIR"/*.gif; do
            [ -f "$gif" ] || continue
            before=$(stat -c%s "$gif" 2>/dev/null || stat -f%z "$gif")
            before_total=$((before_total + before))

            echo -n "  $(basename "$gif") ... "
            gifsicle --lossy=80 --optimize=3 --resize-width 480 \
                -o "$gif.tmp" "$gif" 2>/dev/null

            after=$(stat -c%s "$gif.tmp" 2>/dev/null || stat -f%z "$gif.tmp")
            after_total=$((after_total + after))

            mv "$gif.tmp" "$gif"
            pct=$(( (before - after) * 100 / before ))
            echo "$(numfmt --to=iec "$before") -> $(numfmt --to=iec "$after") (-${pct}%)"
            gif_count=$((gif_count + 1))
        done

        if [ "$gif_count" -gt 0 ]; then
            echo ""
            echo "  Compressed $gif_count GIF(s): $(numfmt --to=iec "$before_total") -> $(numfmt --to=iec "$after_total")"

            # Safety backup inside the repo — untracked files survive filter-repo
            # but better safe than sorry
            GIF_BACKUP="$SCRIPT_DIR/.gif-backup"
            rm -rf "$GIF_BACKUP"
            mkdir -p "$GIF_BACKUP"
            cp "$ASSETS_DIR"/*.gif "$GIF_BACKUP/"
            # Keep title.png too since it's referenced in README
            [ -f "$ASSETS_DIR/title.png" ] && cp "$ASSETS_DIR/title.png" "$GIF_BACKUP/"
            echo "  Backed up compressed GIFs to: $GIF_BACKUP"
        fi
        echo ""
    fi
fi

# ── Step 5: Generate manifest ──────────────────────────────────────────────

echo "Writing $MANIFEST ..."
{
    echo "# Theme video manifest — maps themes to their video background files."
    echo "# These are hosted as GitHub release assets and downloaded on demand"
    echo "# by the installer scripts when a theme is selected."
    echo "#"
    echo "# Format: theme_name:file1,file2,..."
    for theme in $(echo "${!THEME_VIDEOS[@]}" | tr ' ' '\n' | sort); do
        echo "${theme}:${THEME_VIDEOS[$theme]}"
    done
} > "$MANIFEST"

echo ""

# ── Step 6: Remove videos from the index ─────────────────────────────────────

echo "Removing .mp4 files from git index..."
git rm --quiet themes/*/*.mp4 2>/dev/null || git rm --quiet $(find themes -name "*.mp4") 2>/dev/null || true
echo ""

# ── Done ─────────────────────────────────────────────────────────────────────

echo "============================================"
echo "  Migration complete. Next steps:"
echo "============================================"
echo ""
echo "  1. Review the staged changes:"
echo "       git status"
echo "       git diff --cached --stat"
echo ""
echo "  2. Commit (do NOT stage Assets/ yet — filter-repo will wipe it):"
echo "       git add videos.conf .gitignore sddm.sh quickshell.sh"
echo "       git commit -m 'move theme videos to GitHub releases'"
echo "       git push"
echo ""
echo "  3. Purge large blobs from git history (on a FRESH CLONE for safety):"
echo "       git clone <repo-url> qylock-clean && cd qylock-clean"
echo "       pip install git-filter-repo"
echo "       git filter-repo --invert-paths --path-glob 'themes/**/*.mp4' --path-glob 'Assets/*.gif'"
echo ""
if [ "$SKIP_GIF" -eq 0 ]; then
    echo "  4. Restore compressed GIFs from backup and commit:"
    echo "       cp .gif-backup/* Assets/"
    echo "       git add Assets/"
    echo "       git commit -m 'add compressed gallery gifs'"
    echo ""
    echo "  5. Force push:"
else
    echo "  4. Force push:"
fi
echo "       git push origin --force --all"
echo ""
echo "  WARNING: History rewrite means all collaborators will need"
echo "  to re-clone after the force push."
echo ""
```

### Step 2: Run the migration

```bash
./migrate-videos.sh
```

This will:
1. Scan `themes/` and catalog all 22 .mp4 files across 19 themes
2. Create a GitHub release tagged `theme-videos`
3. Upload each video as `{theme}--{filename}` (e.g. `forest--bg.mp4`, `Genshin--dawn.mp4`)
4. Compress all gallery GIFs in `Assets/` (resize to 480px wide + lossy, expects ~80-90% reduction) and back them up to `.gif-backup/`
5. Regenerate `videos.conf` from the scan
6. `git rm` all .mp4 files from the index

If you don't want to compress the GIFs (or don't have `gifsicle`), pass the flag:

```bash
./migrate-videos.sh --skip-gif-compress
```

### Step 3: Commit and push

**Important:** Do NOT stage `Assets/` in this commit. The compressed GIFs are safe in the working tree (untracked files survive filter-repo) with a backup at `.gif-backup/`. We need to purge the bloated originals from history first, then add the compressed versions fresh.

```bash
git add videos.conf .gitignore sddm.sh quickshell.sh
git commit -m "move theme videos to GitHub releases"
git push
```

### Step 4: Purge from git history (optional but recommended)

This is what actually shrinks the repo. The `filter-repo` command purges both the `.mp4` blobs and the original oversized `.gif` blobs from all history. **Do this on a fresh clone** to be safe.

```bash
git clone https://github.com/Darkkal44/qylock.git qylock-clean
cd qylock-clean

pip install git-filter-repo
git filter-repo --invert-paths --path-glob 'themes/**/*.mp4' --path-glob 'Assets/*.gif'
```

### Step 5: Restore compressed GIFs and force push

The compressed GIFs should still be in `Assets/` (untracked files survive filter-repo). If they're missing for any reason, restore from the backup:

```bash
cp .gif-backup/* Assets/
git add Assets/
git commit -m "add compressed gallery gifs"
git push origin --force --all
```

After the force push, all collaborators will need to re-clone.

**Expected size reduction:** ~973MB pack -> well under 150MB (videos gone entirely, GIFs shrunk from ~116MB to ~10-15MB, all historical bloat purged).

### How it works after migration

When a user runs `sddm.sh` or `quickshell.sh` and picks a video theme:

1. The script checks `videos.conf` for that theme's video files
2. If any are missing from disk, it downloads them from `https://github.com/{owner}/{repo}/releases/download/theme-videos/{theme}--{file}`
3. The repo URL is auto-detected from `git remote origin`, so forks work automatically
4. If the download fails, the user is asked whether to continue without videos

Themes without videos (minecraft, nier-automata, ninja_gaiden, terraria, windows_7) are not in the manifest and are completely unaffected.

### Important: GitHub server-side garbage collection

After `filter-repo` + force push, your **local** repo will be small (~133MB). However, **fresh clones may still be large** (~1GB) because GitHub's server-side storage doesn't immediately garbage-collect unreachable objects after a force push.

This is a [known GitHub limitation](https://github.com/orgs/community/discussions/190183). To actually see the size reduction on clones, you have two options:

1. **Contact GitHub support** and ask them to trigger garbage collection on the repo. This is the recommended approach for established repos (preserves stars, issues, forks).
2. **Delete and re-create the repo** — push the clean history to a fresh repo. This guarantees immediate size reduction but loses stars/issues/forks.

For a fork, option 2 is quick and painless. For the main upstream repo, option 1 is the way to go.

### Proof of concept

This migration was tested end-to-end on a mirror repo:

- **Test repo:** https://github.com/SL-Pirate/qylock-mig
- **Test repo (newly created to remove github cache):** https://github.com/SL-Pirate/qylock-clean
- **Migration log:** https://pastebin.com/gExELv9a

The local clone after migration is ~133MB (down from ~973MB). The release assets are accessible and the installer scripts download them correctly.
