### PR TITLE
fix(game-reset): Ensure complete game state reset in themes

### DIFF
--- a/themes/osu/Main.qml
+++ b/themes/osu/Main.qml
@@ -1694,6 +1694,26 @@ Rectangle {
     }
 
     function resetGame() {
+        // Stop all game timers immediately
+        circleSpawnTimer.stop()
+        gameStartDelay.stop()
+        winCheckTimer.stop()
+
+        // Destroy all existing game objects (circles/sliders)
+        for (var i = 0; i < root.activeCircles.length; i++) {
+            if (root.activeCircles[i]) {
+                // Disconnect signals to prevent them from firing during destruction
+                try { root.activeCircles[i].hitSignal.disconnect(null) } catch(e) {}
+                try { root.activeCircles[i].missSignal.disconnect(null) } catch(e) {}
+                if (typeof root.activeCircles[i].sliderCompleted !== "undefined") {
+                    try { root.activeCircles[i].sliderCompleted.disconnect(null) } catch(e) {}
+                }
+                root.activeCircles[i].destroy()
+            }
+        }
+        root.activeCircles = []
+
+        // Reset all states
         root.gameActive = false
         root.osuFailed = false
         root.osuHealth = 1.0
@@ -1707,7 +1727,7 @@ Rectangle {
         root.osuScore = 0
         root.osuAccuracy = 100.0
         root.osuCircleCount = 0
-        root.activeCircles = []
+        root.patternStep = 0
     }
 
     // Accuracy Check

--- a/themes/osumania/Main.qml
+++ b/themes/osumania/Main.qml
@@ -1141,6 +1141,11 @@ Rectangle {
     }
 
     function resetGame() {
+        // Stop all game timers immediately
+        noteSpawnTimer.stop()
+        gameStartDelay.stop()
+        winCheckTimer.stop()
+
         root.gameActive=false; root.maniaFailed=false
         root.maniaHealth=1.0; root.maniaHits=0; root.maniaMisses=0
         root.mania300s=0; root.mania100s=0; root.mania50s=0


### PR DESCRIPTION
# Problem:

A bug occurred where game objects (Hit Circles, Sliders, and Notes) from previous sessions persisted after clicking "Try Again" or "Reduce Difficulty." Since the internal timers of these objects were still running, they would eventually trigger "Miss" events in the new session, causing unexpected health depletion and combo breaks.
Solution:
Enhanced the resetGame() logic for both Osu and Osumania themes to ensure a complete cleanup of the game state and all active QML objects before starting a new round.

# Key Changes:

1. Osu Theme (themes/osu/Main.qml):

- Timer Management: Explicitly stop all system timers (circleSpawnTimer, gameStartDelay, winCheckTimer) during reset.
- Object Destruction: Iterates through the activeCircles array and calls .destroy() on each object.
- Signal Safety: Disconnects signals (hitSignal, missSignal) before destruction to prevent "phantom" events from affecting the new game state.
- Pattern Reset: Reset patternStep to 0 to ensure the spawn sequence restarts correctly.

2. Osumania Theme (themes/osumania/Main.qml):

- Timer Cleanup: Added logic to stop noteSpawnTimer, gameStartDelay, and winCheckTimer when resetting.
- Consistency: Ensured clearAllNotes() is called to wipe the playfield during difficulty transitions or retries.
Impact:
- Eliminates "phantom misses" caused by leftover objects from higher-difficulty runs.
- Ensures a consistent and fair starting state for every new game attempt.
- Improves overall stability and memory management of the rhythm game screens.