### PR TITLE
Add Nix flake with SDDM themes, Quickshell wrapper, and NixOS module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .git/
+result
+result-*

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <div align="center">
 <pre>
-<a href="#sddm-setup">ꜱᴅᴅᴍ</a>  •  <a href="#quickshell-setup">ǫᴜɪᴄᴋsʜᴇʟʟ</a>  •  <a href="#faq">ꜰᴀǫ</a>  •  <a href="#gallery">ɢᴀʟʟᴇʀʏ</a>  •  <a href="#acknowledgements">ᴀᴄᴋɴᴏᴡʟᴇᴅɢᴇᴍᴇɴᴛꜱ</a>  •  <a href="#credits">ᴄʀᴇᴅɪᴛꜱ</a>
+<a href="#sddm-setup">ꜱᴅᴅᴍ</a>  •  <a href="#quickshell-setup">ǫᴜɪᴄᴋsʜᴇʟʟ</a>  •  <a href="#nixos-setup">ɴɪxᴏs</a>  •  <a href="#faq">ꜰᴀǫ</a>  •  <a href="#gallery">ɢᴀʟʟᴇʀʏ</a>  •  <a href="#acknowledgements">ᴀᴄᴋɴᴏᴡʟᴇᴅɢᴇᴍᴇɴᴛꜱ</a>  •  <a href="#credits">ᴄʀᴇᴅɪᴛꜱ</a>
 </pre>
 </div>
 
@@ -122,7 +122,72 @@ Point your Window Manager keybind (e.g., in Hyprland, Qtile, Sway, or i3) direct
 
 <br>
 
+<p align="center">━━━━━━━ ❖ ━━━━━━━</p>
 
+<a id="nixos-setup"></a>
+<br>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/-NIXOS%20SETUP-5277c3?style=for-the-badge&labelColor=1a1b26&logo=nixos&logoColor=white" height="60" />
+</p>
+
+<br>
+
+A flake is provided for NixOS users — no `sddm.sh` / `quickshell.sh` needed. Themes live in the Nix store and the active theme is chosen declaratively.
+
+#### 🚀 USAGE
+
+Add the input and import the module in your `flake.nix`:
+
+```nix
+{
+  inputs.qylock.url = "github:Darkkal44/qylock";
+
+  outputs = { self, nixpkgs, qylock, ... }: {
+    nixosConfigurations.my-host = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        qylock.nixosModules.default
+        ({ pkgs, ... }: {
+          services.displayManager.sddm.enable = true;
+          services.displayManager.sddm.wayland.enable = true;
+
+          programs.qylock = {
+            enable = true;
+            theme = "nier-automata";          # any directory name under themes/
+            # sddm.enable = true;             # installs theme + sets it active (default)
+            # quickshell.enable = true;       # adds `qylock-lock` to PATH (default)
+
+            # Optional per-theme tweaks (replaces the interactive prompts):
+            themeOptions = {
+              terraria.backgroundMode = "time";              # time | random | static
+              Genshin.backgroundMode = "time";
+              clockwork.orbital = { themeMode = "dark"; enableWindup = true; };
+              osu.gameMode = "menu";                         # menu | game
+            };
+          };
+        })
+      ];
+    };
+  };
+}
+```
+
+For the Quickshell lockscreen, bind your WM keybind to `qylock-lock` (instead of `~/.local/share/quickshell-lockscreen/lock.sh`). Pass a theme name as `$1` to override on the fly: `qylock-lock clockwork/tape`.
+
+#### 📦 OUTPUTS
+
+| Output | Purpose |
+|--:|:---|
+| `packages.<sys>.qylock-sddm-themes` | SDDM themes under `share/sddm/themes/` |
+| `packages.<sys>.qylock-quickshell` | `qylock-lock` wrapper with Qt6 QML deps wired in |
+| `devShells.<sys>.default` | `quickshell`, qt6, gstreamer, fzf — to run the bash scripts locally |
+| `nixosModules.default` | `programs.qylock.*` options shown above |
+
+> [!NOTE]
+> The flake pins `nixos-unstable` because `quickshell` isn't in stable nixpkgs yet. If your system tracks a stable channel, override the flake's `nixpkgs` input to your unstable channel.
+
+<br>
 
 <p align="center">━━━━━━━ ◈ ━━━━━━━</p>
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1780243769,
+        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -87,9 +87,13 @@
               cp -r themes $out/share/qylock/themes
 
               mkdir -p $out/bin
+              qmlPath="${pkgs.qt6.qt5compat}/lib/qt-6/qml:${pkgs.qt6.qtdeclarative}/lib/qt-6/qml:${pkgs.qt6.qtmultimedia}/lib/qt-6/qml:${pkgs.qt6.qtsvg}/lib/qt-6/qml"
+
               makeWrapper $out/share/qylock/lock.sh $out/bin/qylock-lock \
                 --set-default QS_THEME "${defaultTheme}" \
                 --set QYLOCK_THEMES_ROOT "$out/share/qylock/themes" \
+                --suffix QML2_IMPORT_PATH : "$qmlPath" \
+                --suffix QML_IMPORT_PATH : "$qmlPath" \
                 --prefix PATH : ${pkgs.lib.makeBinPath [
                   pkgs.quickshell
                   pkgs.psmisc

--- a/flake.nix
+++ b/flake.nix
@@ -101,9 +101,22 @@
                   pkgs.coreutils
                 ]}
 
-              # Patch lock.sh so it resolves the theme path from the wrapper's
-              # QYLOCK_THEMES_ROOT instead of ../themes or themes_link.
+              # Patch lock.sh so it (1) resolves the theme path from the wrapper's
+              # QYLOCK_THEMES_ROOT instead of ../themes or themes_link, and
+              # (2) honours the env-provided QS_THEME (with $1 still overriding)
+              # instead of clobbering it via ~/.config/qylock/theme or a
+              # hardcoded fallback.
               substituteInPlace $out/share/qylock/lock.sh \
+                --replace-fail \
+                  'CONFIG_FILE="$HOME/.config/qylock/theme"
+if [ -n "$1" ]; then
+    export QS_THEME="$1"
+elif [ -f "$CONFIG_FILE" ]; then
+    export QS_THEME=$(cat "$CONFIG_FILE")
+else
+    export QS_THEME="nier-automata"
+fi' \
+                  'if [ -n "$1" ]; then export QS_THEME="$1"; fi' \
                 --replace-fail \
                   'if [ -d "$DIR/../themes" ] && [ ! -d "$DIR/themes_link" ]; then
     export QS_THEME_PATH="$DIR/../themes/$QS_THEME"

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,198 @@
+{
+  description = "qylock — SDDM and Quickshell lockscreen themes";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    let
+      # Apply per-theme variant tweaks (theme.conf edits) inside a derivation.
+      # `themeOptions` shape mirrors what the bash installers prompted for.
+      mkConfEdits = themeOptions:
+        let
+          opt = name: themeOptions.${name} or { };
+          terraria = opt "terraria";
+          genshin = opt "Genshin";
+          clockworkOrbital = (opt "clockwork").orbital or { };
+          clockworkTape = (opt "clockwork").tape or { };
+          osu = opt "osu";
+          osumania = opt "osumania";
+          sed = file: pat: ''
+            if [ -f "${file}" ]; then sed -i "${pat}" "${file}"; fi
+          '';
+        in ''
+          ${nixpkgs.lib.optionalString (terraria ? backgroundMode)
+            (sed "themes/terraria/theme.conf"
+              "s/^background_mode=.*/background_mode=${terraria.backgroundMode}/")}
+          ${nixpkgs.lib.optionalString (terraria ? backgroundIndex)
+            (sed "themes/terraria/theme.conf"
+              "s/^background_index=.*/background_index=${toString terraria.backgroundIndex}/")}
+          ${nixpkgs.lib.optionalString (genshin ? backgroundMode)
+            (sed "themes/Genshin/theme.conf"
+              "s/^background_mode=.*/background_mode=${genshin.backgroundMode}/")}
+          ${nixpkgs.lib.optionalString (genshin ? backgroundIndex)
+            (sed "themes/Genshin/theme.conf"
+              "s/^background_index=.*/background_index=${toString genshin.backgroundIndex}/")}
+          ${nixpkgs.lib.optionalString (clockworkOrbital ? themeMode)
+            (sed "themes/clockwork/orbital/theme.conf"
+              "s/^themeMode=.*/themeMode=${clockworkOrbital.themeMode}/")}
+          ${nixpkgs.lib.optionalString (clockworkOrbital ? enableWindup)
+            (sed "themes/clockwork/orbital/theme.conf"
+              "s/^enableWindup=.*/enableWindup=${if clockworkOrbital.enableWindup then "true" else "false"}/")}
+          ${nixpkgs.lib.optionalString (clockworkTape ? themeMode)
+            (sed "themes/clockwork/tape/theme.conf"
+              "s/^themeMode=.*/themeMode=${clockworkTape.themeMode}/")}
+          ${nixpkgs.lib.optionalString (osu ? gameMode)
+            (sed "themes/osu/theme.conf"
+              "s/^gameMode=.*/gameMode=${osu.gameMode}/")}
+          ${nixpkgs.lib.optionalString (osumania ? gameMode)
+            (sed "themes/osumania/theme.conf"
+              "s/^gameMode=.*/gameMode=${osumania.gameMode}/")}
+        '';
+    in flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+
+        mkSddmThemes = { themeOptions ? { } }:
+          pkgs.stdenvNoCC.mkDerivation {
+            pname = "qylock-sddm-themes";
+            version = "unstable";
+            src = ./.;
+            dontBuild = true;
+            installPhase = ''
+              runHook preInstall
+              ${mkConfEdits themeOptions}
+              mkdir -p $out/share/sddm/themes
+              cp -r themes/. $out/share/sddm/themes/
+              runHook postInstall
+            '';
+            meta.description = "qylock SDDM lockscreen themes";
+          };
+
+        mkQuickshell = { defaultTheme ? "nier-automata", themeOptions ? { } }:
+          pkgs.stdenvNoCC.mkDerivation {
+            pname = "qylock-quickshell";
+            version = "unstable";
+            src = ./.;
+            nativeBuildInputs = [ pkgs.makeWrapper ];
+            dontBuild = true;
+            installPhase = ''
+              runHook preInstall
+              ${mkConfEdits themeOptions}
+
+              mkdir -p $out/share/qylock
+              cp -r quickshell-lockscreen/. $out/share/qylock/
+              cp -r themes $out/share/qylock/themes
+
+              mkdir -p $out/bin
+              makeWrapper $out/share/qylock/lock.sh $out/bin/qylock-lock \
+                --set-default QS_THEME "${defaultTheme}" \
+                --set QYLOCK_THEMES_ROOT "$out/share/qylock/themes" \
+                --prefix PATH : ${pkgs.lib.makeBinPath [
+                  pkgs.quickshell
+                  pkgs.psmisc
+                  pkgs.systemd
+                  pkgs.coreutils
+                ]}
+
+              # Patch lock.sh so it resolves the theme path from the wrapper's
+              # QYLOCK_THEMES_ROOT instead of ../themes or themes_link.
+              substituteInPlace $out/share/qylock/lock.sh \
+                --replace-fail \
+                  'if [ -d "$DIR/../themes" ] && [ ! -d "$DIR/themes_link" ]; then
+    export QS_THEME_PATH="$DIR/../themes/$QS_THEME"
+else
+    export QS_THEME_PATH="$DIR/themes_link/$QS_THEME"
+fi' \
+                  'export QS_THEME_PATH="$QYLOCK_THEMES_ROOT/$QS_THEME"'
+
+              runHook postInstall
+            '';
+            meta = {
+              description = "qylock Quickshell lockscreen wrapper";
+              mainProgram = "qylock-lock";
+            };
+          };
+      in {
+        packages = {
+          qylock-sddm-themes = mkSddmThemes { };
+          qylock-quickshell = mkQuickshell { };
+          default = mkQuickshell { };
+        };
+
+        # Expose builders so the NixOS module can pass user options through.
+        legacyPackages = {
+          inherit mkSddmThemes mkQuickshell;
+        };
+
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            quickshell
+            qt6.qtdeclarative
+            qt6.qt5compat
+            qt6.qtsvg
+            qt6.qtmultimedia
+            gst_all_1.gstreamer
+            gst_all_1.gst-plugins-base
+            gst_all_1.gst-plugins-good
+            gst_all_1.gst-plugins-bad
+            gst_all_1.gst-plugins-ugly
+            fzf
+          ];
+        };
+      }) // {
+        nixosModules.default = { config, lib, pkgs, ... }:
+          let
+            cfg = config.programs.qylock;
+            builders = self.legacyPackages.${pkgs.system};
+            sddmPkg = builders.mkSddmThemes { themeOptions = cfg.themeOptions; };
+            qsPkg = builders.mkQuickshell {
+              defaultTheme = cfg.theme;
+              themeOptions = cfg.themeOptions;
+            };
+          in {
+            options.programs.qylock = {
+              enable = lib.mkEnableOption "qylock lockscreen themes";
+              theme = lib.mkOption {
+                type = lib.types.str;
+                default = "nier-automata";
+                description = "Theme directory name under themes/ to activate.";
+              };
+              sddm.enable = lib.mkOption {
+                type = lib.types.bool;
+                default = true;
+                description = "Install SDDM themes and set the active theme.";
+              };
+              quickshell.enable = lib.mkOption {
+                type = lib.types.bool;
+                default = true;
+                description = "Install the Quickshell lockscreen wrapper (qylock-lock).";
+              };
+              themeOptions = lib.mkOption {
+                type = lib.types.attrs;
+                default = { };
+                example = lib.literalExpression ''
+                  {
+                    clockwork.orbital = { themeMode = "light"; enableWindup = false; };
+                    terraria = { backgroundMode = "time"; };
+                  }
+                '';
+                description = "Per-theme tweaks applied to theme.conf at build time.";
+              };
+            };
+
+            config = lib.mkIf cfg.enable (lib.mkMerge [
+              (lib.mkIf cfg.sddm.enable {
+                services.displayManager.sddm.theme = cfg.theme;
+                services.displayManager.sddm.extraPackages = [ sddmPkg ];
+                environment.systemPackages = [ sddmPkg ];
+              })
+              (lib.mkIf cfg.quickshell.enable {
+                environment.systemPackages = [ qsPkg ];
+              })
+            ]);
+          };
+      };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -203,7 +203,14 @@ fi' \
             config = lib.mkIf cfg.enable (lib.mkMerge [
               (lib.mkIf cfg.sddm.enable {
                 services.displayManager.sddm.theme = cfg.theme;
-                services.displayManager.sddm.extraPackages = [ sddmPkg ];
+                services.displayManager.sddm.extraPackages = [
+                  sddmPkg
+                  # QML modules the themes import (e.g. Qt5Compat.GraphicalEffects).
+                  # extraPackages contributes lib/qt-6/qml to the greeter's QML_IMPORT_PATH.
+                  pkgs.qt6.qt5compat
+                  pkgs.qt6.qtmultimedia
+                  pkgs.qt6.qtsvg
+                ];
                 environment.systemPackages = [ sddmPkg ];
               })
               (lib.mkIf cfg.quickshell.enable {


### PR DESCRIPTION
# Summary
Adds a barebones flake.nix so NixOS users can install qylock declaratively, without running sddm.sh / quickshell.sh.

This is a complete rewrite of my previous pull request with the new qt6 library changes.

## What's Included

- **packages.\<sys>.qylock-sddm-themes**: themes installed under `share/sddm/themes/`, ready for `services.displayManager.sddm.theme`.
- **packages.\<sys>.qylock-quickshell**: exposes qylock-lock (wrapper around lock.sh) with quickshell, killall, loginctl, and the Qt6 QML modules wired in.
- Dev shell with all the runtime dependencies.

## Notes
- `themes/` and `quickshell-lockscreen/` are consumed as-is with no source changes
- `lock.sh` is patched at build time to resolve `QS_THEME_PATH` from the wrapper-provided `QYLOCK_THEMES_ROOT` and to honor the env-set `QS_THEME` instead of falling back to `~/.config/qylock/theme` or hardcoded `nier-automata`
- README gets a `NIXOS SETUP` section with a complete example config.
- Flake pins `nixos-unstable` because `quickshell` isn't in stable nixpkgs yet.

---

## Personal Note

  Apologies for the previous PR going cold. Life got in the way (finals, work, health) right as the upstream Qt changes landed, and by the time I had bandwidth to come back to it the diff had drifted enough that it was cleaner to start fresh against current main. Thanks for your patience.