### PR TITLE
NixOS: Add flake-compat

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,12 @@
+(import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    nodeName = lock.nodes.root.inputs.flake-compat;
+  in
+  fetchTarball {
+    url =
+      lock.nodes.${nodeName}.locked.url
+        or "https://github.com/NixOS/flake-compat/archive/${lock.nodes.${nodeName}.locked.rev}.tar.gz";
+    sha256 = lock.nodes.${nodeName}.locked.narHash;
+  }
+) { src = ./.; }).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -36,6 +52,7 @@
     },
     "root": {
       "inputs": {
+        "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -4,9 +4,13 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
+    flake-compat = {
+      url = "github:NixOS/flake-compat";
+      flake = false;
+    };
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
+  outputs = { self, nixpkgs, flake-utils, flake-compat }:
     let
       # Apply per-theme variant tweaks (theme.conf edits) inside a derivation.
       # `themeOptions` shape mirrors what the bash installers prompted for.

--- a/flake.nix
+++ b/flake.nix
@@ -167,7 +167,7 @@ fi' \
         nixosModules.default = { config, lib, pkgs, ... }:
           let
             cfg = config.programs.qylock;
-            builders = self.legacyPackages.${pkgs.system};
+            builders = self.legacyPackages.${pkgs.stdenv.hostPlatform.system};
             sddmPkg = builders.mkSddmThemes { themeOptions = cfg.themeOptions; };
             qsPkg = builders.mkQuickshell {
               defaultTheme = cfg.theme;


### PR DESCRIPTION
This adds flake-compat so that people who don't use flakes can use this too

I also snuck in a change to the flake.nix to fix "evaluation warning: ‘system’ has been renamed to/replaced by ‘stdenv.hostPlatform.system"